### PR TITLE
Read config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ vendor/
 
 # Executable
 labchat
+
+# Configuration file.
+labchat.conf.yaml

--- a/entry/bootstrap.go
+++ b/entry/bootstrap.go
@@ -10,6 +10,11 @@ import (
 	"github.com/yoonsue/labchat/server"
 )
 
+// defaultConfigPath is the default location where labchat looks for
+// a configuration file.
+// TODO: allow to change configuration file path by command-line interface.
+const defaultConfigPath = "./labchat.conf.yaml"
+
 // Bootstrap is the entry point for running the labchat server.
 // It generates the necessary configuration files and creates the components
 // of the system, and injects the dependencies according to its hierarchy.
@@ -17,15 +22,24 @@ func Bootstrap() {
 	// TODO: load the configuration.
 	log.Println("bootstrap the labchat service")
 
-	log.Println("create the labchat server")
+	yamlConfig, err := readConfig(defaultConfigPath)
+	if err != nil {
+		log.Fatal(errors.Wrap(err, "failed to read configuration file"))
+	}
+	log.Println("read configuration file")
+
 	serverConfig := server.DefaultConfig()
+	serverConfig.Address = yamlConfig.Address
+	log.Println("make server configuration")
+
 	labchat, err := server.NewServer(serverConfig)
 	if err != nil {
 		log.Fatal(errors.Wrap(err, "failed to create labchat server"))
 	}
+	log.Println("create the labchat server")
 
-	log.Println("run the labchat server")
 	labchat.Start()
+	log.Printf("run the labchat server at %s", serverConfig.Address)
 
 	sigc := make(chan os.Signal, 1)
 	signal.Notify(sigc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt, os.Kill)

--- a/entry/config.go
+++ b/entry/config.go
@@ -1,0 +1,30 @@
+package entry
+
+import (
+	"io/ioutil"
+
+	"github.com/ghodss/yaml"
+)
+
+// yamlConfig contains information for running labchat.
+// Read from the file: {config_path}/labchat.conf.yaml
+type yamlConfig struct {
+	Address string `json:"address"`
+}
+
+// readConfig reads configuration from the configuration file.
+func readConfig(fpath string) (*yamlConfig, error) {
+	b, err := ioutil.ReadFile(fpath)
+	if err != nil {
+		return nil, err
+	}
+
+	yc := &yamlConfig{}
+
+	err = yaml.Unmarshal(b, yc)
+	if err != nil {
+		return nil, err
+	}
+
+	return yc, nil
+}

--- a/entry/config_test.go
+++ b/entry/config_test.go
@@ -1,0 +1,42 @@
+package entry
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/ghodss/yaml"
+)
+
+func TestReadConfig(t *testing.T) {
+	yc := &yamlConfig{
+		Address: "localhost:2300",
+	}
+
+	tmpFile, err := ioutil.TempFile("", "client.cfg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	b, err := yaml.Marshal(yc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = tmpFile.Write(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := readConfig(tmpFile.Name())
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if cfg.Address != yc.Address {
+		t.Errorf("expected %s, got %s", yc.Address, cfg.Address)
+	}
+}

--- a/labchat.conf.yaml.sample
+++ b/labchat.conf.yaml.sample
@@ -1,0 +1,4 @@
+# This is the configuration file for the labchat server.
+
+# Address of the labchat service.
+address: localhost:4748

--- a/server/config.go
+++ b/server/config.go
@@ -3,9 +3,12 @@ package server
 // Config is the value holder of the configurations of labchat server.
 type Config struct {
 	// TODO: implementation.
+	Address string
 }
 
 // DefaultConfig returns the default setting of the labchat configuration.
 func DefaultConfig() *Config {
-	return &Config{}
+	return &Config{
+		Address: "localhost:4748",
+	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -4,15 +4,21 @@ import (
 	"net/http"
 )
 
+// Address is for server address.
+type Address string
+
 // Server provides http service for the labchat service.
 type Server struct {
 	// TODO: implementation.
+	cfg *Config
 }
 
 // NewServer creates a new labchat server with the given configuration.
 func NewServer(cfg *Config) (srv *Server, err error) {
 	// TODO: implementation.
-	return nil, nil
+	return &Server{
+		cfg: cfg,
+	}, nil
 }
 
 // Start runs the server and starts handling for incoming requests. All the
@@ -23,5 +29,6 @@ func (s *Server) Start() {
 		res.Write([]byte("Hello, world!"))
 	})
 
-	http.ListenAndServe(":80", nil)
+	// TODO: need to halt goroutine when the program is stopped.
+	go http.ListenAndServe(s.cfg.Address, nil)
 }


### PR DESCRIPTION
Supports to read configuration file and the supported file type is *.yaml.
The default configuration file path is currently "~/labchat.conf.yaml" by hard coded.
Recommend that allow to the user can modify the configuration file path through command-line interface.